### PR TITLE
RIOT: bump to 2020.01

### DIFF
--- a/exercises/riot-networking/gcoap-iotlab/.solution/main.c
+++ b/exercises/riot-networking/gcoap-iotlab/.solution/main.c
@@ -24,6 +24,7 @@ static const coap_resource_t _resources[] = {
 static gcoap_listener_t _listener = {
     &_resources[0],
     sizeof(_resources) / sizeof(_resources[0]),
+    NULL,
     NULL
 };
 

--- a/exercises/riot-networking/gcoap/.solution/main.c
+++ b/exercises/riot-networking/gcoap/.solution/main.c
@@ -23,6 +23,7 @@ static const coap_resource_t _resources[] = {
 static gcoap_listener_t _listener = {
     &_resources[0],
     sizeof(_resources) / sizeof(_resources[0]),
+    NULL,
     NULL
 };
 


### PR DESCRIPTION
This PR bumps the version to 2020.01. I tested all `.solutions`:

- `riot-basics` all
- `getting-started` all
- `riot-lorawan` I only tested the RIOT part no integration with upstream
- `riot-networking` all the ones that are not in `examples`