### PR TITLE
Bump RIOT to 2020.04

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "RIOT"]
 	path = RIOT
 	url = https://github.com/RIOT-OS/RIOT
-	branch = 2019.04-branch
+	branch = 2020.04-branch

--- a/exercises/riot-lorawan/pm/.solution/Makefile
+++ b/exercises/riot-lorawan/pm/.solution/Makefile
@@ -23,6 +23,6 @@ DEVELHELP ?= 1
 RIOTBASE ?= $(CURDIR)/../../../../RIOT
 
 # Enable lowest possible power mode (e.g. STANDBY mode on STM32)
-CFLAGS += '-DPM_BLOCKER_INITIAL={ .val_u32 = 0x01010100 }'
+CFLAGS += -DPM_BLOCKER_INITIAL=0x01010100
 
 include $(RIOTBASE)/Makefile.include

--- a/exercises/riot-lorawan/pm/README.md
+++ b/exercises/riot-lorawan/pm/README.md
@@ -11,7 +11,7 @@ for reducing power consumption (using STANDBY low power mode).
 - In the application Makefile, unlock by default the STANDBY low power mode by
   adding before the line `include $(RIOTBASE)/Makefile.include`:
   ```
-  CFLAGS += '-DPM_BLOCKER_INITIAL={ .val_u32 = 0x01010100 }'
+  CFLAGS += -DPM_BLOCKER_INITIAL=0x01010100
   ```
 - Still in the application Makefile, add the required RTC and EEPROM features:
   ```


### PR DESCRIPTION
Had to fix an incompatibility issue with the PM_BLOCKER_INITIAL define.

cc @fjmolinas